### PR TITLE
Fixes for compiling with clang

### DIFF
--- a/rstex.cpp.pre
+++ b/rstex.cpp.pre
@@ -222,7 +222,7 @@ void print(int s)
 	int nl;
 
 	if (s >= str_ptr) s = TEX_STRING("???");
-	else if (s < 256)
+	else if (s < 256) {
 		if (s < 0) s = TEX_STRING("???");
 		else {
 			if (selector > pseudo) {
@@ -243,6 +243,7 @@ void print(int s)
 			}
 			new_line_char = nl; return;
 		}
+	}
 
 
 	j = str_start[s];
@@ -1893,7 +1894,7 @@ restart:
 			t = info(loc); loc = link(loc);
 			if (t >= cs_token_flag) {
 				cur_cs = t - cs_token_flag; cur_cmd = eq_type(cur_cs); cur_chr = equiv(cur_cs);
-				if (cur_cmd >= outer_call)
+				if (cur_cmd >= outer_call) {
 					if (cur_cmd == dont_expand)
 						#pragma region <Get the next token, suppressing expansion 358>
 					{						
@@ -1905,6 +1906,7 @@ restart:
 					}
 						#pragma endregion
 					else check_outer_validity();
+				}
 			}
 			else {
 				cur_cmd = t / 0400; cur_chr = t % 0400;
@@ -2386,11 +2388,12 @@ void back_input()
 	while (state == token_list && loc == null && token_type != v_template)
 		end_token_list();
 	p = get_avail(); info(p) = cur_tok;
-	if (cur_tok < right_brace_limit)
+	if (cur_tok < right_brace_limit) {
 		if (cur_tok < left_brace_limit)
 			decr(align_state);
 		else
 			incr(align_state);
+	}
 	push_input;
 	state = token_list;
 	start = p; token_type = backed_up; loc = p;
@@ -2841,9 +2844,10 @@ void show_node_list(int p)
 				case left_noad: print_esc(TEX_STRING("left")); print_delimiter(delimiter(p)); break;
 				case right_noad: print_esc(TEX_STRING("right")); print_delimiter(delimiter(p)); break;
 				}
-				if (subtype(p) != normal)
+				if (subtype(p) != normal) {
 					if (subtype(p) == limits) print_esc(TEX_STRING("limits"));
 					else print_esc(TEX_STRING("nolimits"));
+				}
 				if (type(p) < left_noad) print_subsidiary_data(nucleus(p), TEX_STRING("."));
 				print_subsidiary_data(supscr(p), TEX_STRING("^")); print_subsidiary_data(subscr(p), TEX_STRING("_"));
 
@@ -3836,7 +3840,7 @@ void prompt_file_name(str_number s, str_number e)
 		print_err(TEX_STRING("I can't find file `"));
 	else print_err(TEX_STRING("I can't write on file `"));
 	print_file_name(cur_name, cur_area, cur_ext); print(TEX_STRING("'."));
-	if (e = TEX_STRING(".tex")) show_context();
+	if (e == TEX_STRING(".tex")) show_context();
 	print_nl(TEX_STRING("Please type another ")); print(s);
 	if (interaction < scroll_mode)
 		fatal_error(TEX_STRING("*** (job aborted, file error in nonstop mode)"));
@@ -4992,7 +4996,7 @@ restart:
 									while (1) {
 										#pragma region <If instruction cur_i is a kern with cur_c, attach the kern after q; or.. 753>
 										if(next_char(cur_i) == cur_c)
-											if(skip_byte(cur_i)<=stop_flag)
+											if(skip_byte(cur_i)<=stop_flag) {
 												if (op_byte(cur_i) >= kern_flag) {
 													p = new_kern(char_kern(cur_f, cur_i)); link(p) = link(q); link(q) = p; return;
 												}
@@ -5025,6 +5029,7 @@ restart:
 													if (op_byte(cur_i) > qi(3)) return;
 													math_type(nucleus(q)) = math_char; goto restart;
 												}
+											}
 										#pragma endregion
 										if (skip_byte(cur_i) >= stop_flag) return;
 										a += qo(skip_byte(cur_i)) + 1; cur_i = font_info[a].union_t.qqqq;
@@ -5323,7 +5328,7 @@ void fin_align()
 	#pragma region <Set the glue in all the unset boxes of the current list 805>
 	q = link(head); s = head;
 	while (q != null) {
-		if(!is_char_node(q))
+		if(!is_char_node(q)) {
 			if (type(q) == unset_node)
 				#pragma region <Set the unset box q and the unset boxes in it 807>
 			{
@@ -5422,6 +5427,7 @@ void fin_align()
 					link(s) = q;
 				}
 			}
+		}
 #pragma endregion
 		s = q; q = link(q);
 	}
@@ -6046,7 +6052,7 @@ void handle_right_brace()
 		unsave(); decr(save_ptr);
 		math_type(saved(0)) = sub_mlist; p = fin_mlist(null); info(saved(0)) = p;
 		if(p!=null)
-			if(link(p)==null)
+			if(link(p)==null) {
 				if (type(p) == ord_noad) {
 					if(math_type(subscr(p))==empty)
 						if (math_type(supscr(p)) == empty) {
@@ -6063,7 +6069,7 @@ void handle_right_brace()
 							link(q) = p; free_node(tail, noad_size); tail = p;
 						}
 							#pragma endregion
-						
+			}
 		break;
 	#pragma endregion
 	default:
@@ -7142,19 +7148,20 @@ not_found:
 
 	#pragma endregion
 
-	if (mu)
+	if (mu) {
 		#pragma region <Scan for mu units and goto attach_fraction 456>
-	if (scan_keyword(TEX_STRING("mu"))) goto attach_fraction;
-	else {
-		print_err(TEX_STRING("Illegal unit of measure ("));
-		print(TEX_STRING("mu inserted)"));
-		help4(TEX_STRING("The unit of measurement in math glue must be mu."),
-			TEX_STRING("To recover gracefully from this error, it's best to"),
-			TEX_STRING("delete the erroneous units; e.g., type `2' to delete"),
-			TEX_STRING("two letters. (See Chapter 27 of The TeXbook.)"));
-		error(); goto attach_fraction;
-	}
+		if (scan_keyword(TEX_STRING("mu"))) goto attach_fraction;
+		else {
+			print_err(TEX_STRING("Illegal unit of measure ("));
+			print(TEX_STRING("mu inserted)"));
+			help4(TEX_STRING("The unit of measurement in math glue must be mu."),
+				TEX_STRING("To recover gracefully from this error, it's best to"),
+				TEX_STRING("delete the erroneous units; e.g., type `2' to delete"),
+				TEX_STRING("two letters. (See Chapter 27 of The TeXbook.)"));
+			error(); goto attach_fraction;
+		}
 		#pragma endregion
+	}
 
 	if (scan_keyword(TEX_STRING("true")))
 		#pragma region <Adjust for magnification ratio 457>
@@ -7841,9 +7848,9 @@ void macro_call()
 				#pragma endregion
 
 			#pragma region <Contribute the recently matched tokens to the current paramter, and goto continue if a partial match... 397>			
-			if (s != r)
+			if (s != r) {
 				if (s == null)
-					#pragma region <Report an improper use of teh macro and abort 398>
+				#pragma region <Report an improper use of teh macro and abort 398>
 				{
 					print_err(TEX_STRING("Use of "));
 					sprint_cs(warning_index);
@@ -7855,24 +7862,26 @@ void macro_call()
 					error();
 					goto _exit;
 				}
-					#pragma endregion
+				#pragma endregion
 				else {
 					t = s;
 					do {
 						store_new_token(info(t)); incr(m); u = link(t); v = s;
 						while (1) {
-							if (u == r)
+							if (u == r) {
 								if (cur_tok != info(v)) goto done;
 								else {
 									r = link(v); goto mycontinue;
 								}
-								if (info(u) != info(v)) goto done;
-								u = link(u); v = link(v);
+							}
+							if (info(u) != info(v)) goto done;
+							u = link(u); v = link(v);
 						}
 					done: t = link(t);
 					} while (!(t == r));
 					r = s;
 				}
+			}
 
 			#pragma endregion
 			if (cur_tok == par_token)
@@ -7919,12 +7928,13 @@ void macro_call()
 								goto _exit;
 							}
 								#pragma endregion
-						if(cur_tok < right_brace_limit)
+						if(cur_tok < right_brace_limit) {
 							if (cur_tok < left_brace_limit) incr(unbalance);
 							else {
 								decr(unbalance);
 								if (unbalance == 0) goto done1;
 							}
+						}
 					}
 				done1: rbrace_ptr = p; store_new_token(cur_tok);
 				}
@@ -8230,9 +8240,10 @@ void end_token_list()
 				}
 		}
 	}
-	else if (token_type == u_template)
+	else if (token_type == u_template) {
 		if (align_state > 500000) align_state = 0;
 		else fatal_error(TEX_STRING("(interwoven alignment preambles are not allowed)"));
+	}
 
 	pop_input; check_interrupt;
 }
@@ -8372,7 +8383,7 @@ pointer scan_toks(bool macro_def, bool xpand)
 				s = cur_tok;
 				if (xpand) get_x_token();
 				else get_token();
-				if(cur_cmd != mac_param)
+				if(cur_cmd != mac_param) {
 					if (cur_tok <= zero_token || cur_tok > t) {
 						print_err(TEX_STRING("Illegal parameter number in definition of "));
 						sprint_cs(warning_index);
@@ -8383,6 +8394,7 @@ pointer scan_toks(bool macro_def, bool xpand)
 						cur_tok = s;
 					}
 					else cur_tok = out_param_token - TEX_STRING("0") + cur_chr;
+				}
 			}
 				#pragma endregion
 		store_new_token(cur_tok);
@@ -8618,9 +8630,10 @@ internal_font_number read_font_info(pointer u, str_number nom, str_number aire, 
 		decr(lh);
 	}
 	font_dsize[f] = z;
-	if (s != -1000)
+	if (s != -1000) {
 		if (s >= 0) z = s;
 		else z = xn_over_d(z, -s, 1000);
+	}
 	font_size[f] = z;
 	#pragma endregion
 
@@ -9661,9 +9674,10 @@ void try_break(int pi, small_number break_type)
 	#pragma endregion
 
 	#pragma region <Make sure that pi is in the proper range 831>
-	if (myabs(pi) >= inf_penalty)
+	if (myabs(pi) >= inf_penalty) {
 		if (pi > 0) goto myexit;
 		else pi = eject_penalty;
+	}
 	#pragma endregion
 
 	no_break_yet = true; prev_r = active; old_l = 0; do_all_six(copy_to_cur_active);
@@ -9900,12 +9914,14 @@ void try_break(int pi, small_number break_type)
 			{
 				d = line_penalty + b;
 				if (myabs(d) >= 10000) d = 100000000; else d = d * d;
-				if (pi != 0)
+				if (pi != 0) {
 					if (pi > 0) d = d + pi * pi;
 					else if (pi > eject_penalty) d = d - pi * pi;
-				if (break_type == hyphenated && type(r) == hyphenated)
+				}
+				if (break_type == hyphenated && type(r) == hyphenated) {
 					if (cur_p != null) d = d + double_hyphen_demerits;
 					else d = d + final_hyphen_demerits;
+				}
 				if (myabs(fit_class - fitness(r)) > 1) d = d + adj_demerits;
 			}
 				#pragma endregion
@@ -10033,7 +10049,7 @@ void box_end(int box_context)
 		else geq_define(box_base - box_flag - 256 + box_context, box_ref, cur_box);
 	}
 		#pragma endregion
-	else if(cur_box != null)
+	else if(cur_box != null) {
 		if (box_context > ship_out_flag) 
 			#pragma region <Append a new leader node that uses cur_box 1078>
 		{
@@ -10058,6 +10074,7 @@ void box_end(int box_context)
 		}
 			#pragma endregion
 		else ship_out(cur_box);
+	}
 }
 
 
@@ -11092,11 +11109,12 @@ void scan_int()
 		get_token();
 		if (cur_tok < cs_token_flag) {
 			cur_val = cur_chr;
-			if (cur_cmd <= right_brace)
+			if (cur_cmd <= right_brace) {
 				if (cur_cmd == right_brace)
 					incr(align_state);
 				else
 					decr(align_state);
+			}
 		}
 		else if (cur_tok < cs_token_flag + single_base)
 			cur_val = cur_tok - cs_token_flag - active_base;
@@ -11530,13 +11548,14 @@ void prefixed_command()
 	#pragma endregion
 
 	#pragma region <Adjust for the setting of globaldefs 1214>
-	if(global_defs != 0)
+	if(global_defs != 0) {
 		if (global_defs < 0) {
 			if (global) a -= 4;
 		}
 		else {
 			if (!global) a += 4;
 		}
+	}
 	#pragma endregion
 
 	switch (cur_cmd) {
@@ -11993,9 +12012,10 @@ void fire_up(pointer c)
 	split_top_skip = save_split_top_skip;
 	#pragma region <Break the current page at node p, put it in box 255, and put the remaining nodes on the contribution list 1017>
 	if (p != null) {
-		if (link(contrib_head) == null)
+		if (link(contrib_head) == null) {
 			if (nest_ptr == 0) tail = page_tail;
 			else contrib_tail = page_tail;
+		}
 		link(page_tail) = link(contrib_head); link(contrib_head) = p; link(prev_p) = null;
 	}
 	save_vbadness = vbadness; vbadness = inf_bad; save_vfuzz = vfuzz; vfuzz = max_dimen;
@@ -12025,7 +12045,7 @@ void fire_up(pointer c)
 	if (top_mark != null && first_mark == null) {
 		first_mark = top_mark; add_token_ref(top_mark);
 	}
-	if (output_routine != null)
+	if (output_routine != null) {
 		if (dead_cycles >= max_dead_cycles) 
 			#pragma region <Explain that too many dead cycles have occurred in a row 1024>
 		{
@@ -12050,6 +12070,7 @@ void fire_up(pointer c)
 			goto _exit;
 		}
 			#pragma endregion
+	}
 
 	#pragma region <Perform the default output routine 1023>
 	{
@@ -12182,13 +12203,14 @@ pointer vert_break(pointer p, scaled h, scaled d)
 			else
 				b = badness(cur_height - h, active_height[6]);
 			#pragma endregion
-			if (b < awful_bad)
+			if (b < awful_bad) {
 				if (pi <= eject_penalty) 
 					b = pi;
 				else if (b < inf_bad) 
 					b += pi;
 				else 
 					b = deplorable;
+			}
 			if (b <= least_cost) {
 				best_place = p; least_cost = b; best_height_plus_depth = cur_height + prev_dp;
 			}
@@ -12280,7 +12302,7 @@ pointer vsplit(eight_bits n, scaled h)
 	p = list_ptr(v);
 	if (p == q) list_ptr(v) = null;
 	else while (1) {
-		if(type(p) == mark_node)
+		if(type(p) == mark_node) {
 			if (split_first_mark == null) {
 				split_first_mark = mark_ptr(p); split_bot_mark = split_first_mark;
 				token_ref_count(split_first_mark) += 2;
@@ -12289,10 +12311,11 @@ pointer vsplit(eight_bits n, scaled h)
 				delete_token_ref(split_bot_mark); split_bot_mark = mark_ptr(p);
 				add_token_ref(split_bot_mark);
 			}
-			if (link(p) == q) {
-				link(p) = null; goto done;
-			}
-			p = link(p);
+		}
+		if (link(p) == q) {
+			link(p) = null; goto done;
+		}
+		p = link(p);
 	}
 done:
 	#pragma endregion
@@ -13510,7 +13533,7 @@ bool fin_col()
 	if (align_state < 500000) fatal_error(TEX_STRING("(interwoven alignment preambles are not allowed)"));
 	p = link(q);
 	#pragma region <If the preamble list has been traversed, check that the row has ended 792>
-	if(p == null && extra_info(cur_align) < cr_code)
+	if(p == null && extra_info(cur_align) < cr_code) {
 		if (cur_loop != null)
 			#pragma region <Lengthen the preamble periodically 793>
 		{
@@ -13539,6 +13562,7 @@ bool fin_col()
 			extra_info(cur_align) = cr_code;
 			error();
 		}
+	}
 
 	#pragma endregion
 
@@ -13921,11 +13945,12 @@ reswitch:
 		init_align();
 		break;
 	case mmode+halign:
-		if (privileged())
+		if (privileged()) {
 			if (cur_group == math_shift_group)
 				init_align();
 			else
 				off_save();
+		}
 		break;
 	case vmode+endv:
 	case hmode+endv:
@@ -13944,10 +13969,11 @@ reswitch:
 
 		// 1140
 	case mmode+eq_no:
-		if (privileged())
+		if (privileged()) {
 			if (cur_group == math_shift_group)
 				start_eq_no();
 			else off_save();
+		}
 
 		break;
 
@@ -15109,9 +15135,10 @@ void line_break(int final_widow_penalty)
 								goto mycontinue;
 							}
 							else goto done1;
-							if (lc_code(c) != 0)
+							if (lc_code(c) != 0) {
 								if (lc_code(c) == c || uc_hyph > 0) goto done2;
 								else goto done1;
+							}
 							mycontinue:
 								prev_s = s; s = link(prev_s);
 						}
@@ -15595,7 +15622,7 @@ mycontinue:
 	while (1)
 	{
 		if(next_char(q) == test_char)
-			if(skip_byte(q)<= stop_flag)
+			if(skip_byte(q)<= stop_flag) {
 				if (cur_rh < non_char) {
 					hyphen_passed = j; hchar = non_char; cur_rh = non_char; goto mycontinue;
 				}
@@ -15678,12 +15705,14 @@ mycontinue:
 						#pragma endregion
 					w = char_kern(hf, q); goto done;
 				}
-				if (skip_byte(q) >= stop_flag)
-					if (cur_rh == non_char) goto done;
-					else {
-						cur_rh = non_char; goto mycontinue;
-					}
-					k = k + qo(skip_byte(q)) + 1; q = font_info[k].union_t.qqqq;
+			}
+		if (skip_byte(q) >= stop_flag) {
+			if (cur_rh == non_char) goto done;
+			else {
+				cur_rh = non_char; goto mycontinue;
+			}
+		}
+		k = k + qo(skip_byte(q)) + 1; q = font_info[k].union_t.qqqq;
 	}
 done:
 

--- a/rstex.cpp.pre
+++ b/rstex.cpp.pre
@@ -336,7 +336,7 @@ void print_ln()
 
 void print_nl(str_number s)
 {
-	if(term_offset > 0 && myodd(selector) || file_offset > 0 && selector >= log_only)
+	if((term_offset > 0 && myodd(selector)) || (file_offset > 0 && selector >= log_only))
 		print_ln();
 	print(s);
 }
@@ -5972,7 +5972,7 @@ void handle_right_brace()
 		break;
 	case group_code::output_group:
 		#pragma region <Resume the page builder after an output routine ahs come to an end 1026>
-		if (loc != null || token_type != output_text && token_type != backed_up) 
+		if (loc != null || (token_type != output_text && token_type != backed_up))
 			#pragma region <Recover from an unbalanced output routine 1027>
 		{
 			print_err(TEX_STRING("Unbalanced output routine"));
@@ -10043,7 +10043,7 @@ void box_end(int box_context)
 				get_x_token();
 			} while (!(cur_cmd != spacer && cur_cmd != relax));
 			#pragma endregion
-			if (cur_cmd == hskip && myabs(mode) != vmode || cur_cmd == vskip && myabs(mode) == vmode) {
+			if ((cur_cmd == hskip && myabs(mode) != vmode) || (cur_cmd == vskip && myabs(mode) == vmode)) {
 				append_glue(); subtype(tail) = box_context - (leader_flag - a_leaders);
 				leader_ptr(tail) = cur_box;
 			}
@@ -11727,7 +11727,7 @@ void prefixed_command()
 		p = p + cur_val;
 		scan_optional_equals();
 		scan_int();
-		if (cur_val < 0 && p < del_code_base || cur_val > n) {
+		if (cur_val < 0 && (p < del_code_base || cur_val > n)) {
 			print_err(TEX_STRING("Invalid code (")); print_int(cur_val);
 			if (p < del_code_base)
 				print(TEX_STRING("), should be in the range 0.."));
@@ -13010,7 +13010,7 @@ bool load_fmt_file()
 	do {
 		for (k = p; k <= q + 1; k++) undump_wd(&mem[k]);
 		p = q + node_size(q);
-		if (p > lo_mem_max || q >= rlink(q) && rlink(q) != rover) goto bad_fmt;
+		if (p > lo_mem_max || (q >= rlink(q) && rlink(q) != rover)) goto bad_fmt;
 		q = rlink(q);
 	} while (!(q == rover));
 	for (k = p; k <= lo_mem_max; k++) undump_wd(&mem[k]);
@@ -14483,7 +14483,7 @@ done:;
 		}
 		#pragma region <Calculate the length, l, and the shift amount, s, of the display lines 1149>
 		if(par_shape_ptr == null)
-			if (hang_indent != 0 && (hang_after >= 0 && prev_graf + 2 > hang_after || prev_graf + 1 < -hang_after)) {
+			if (hang_indent != 0 && ((hang_after >= 0 && prev_graf + 2 > hang_after) || prev_graf + 1 < -hang_after)) {
 				l = hsize - myabs(hang_indent);
 				if (hang_indent > 0) s = hang_indent;
 				else s = 0;
@@ -15305,8 +15305,8 @@ void line_break(int final_widow_penalty)
 				do {
 					if (type(r) != delta_node) {
 						line_diff = line_number(r) - best_line;
-						if (line_diff < actual_looseness && looseness <= line_diff ||
-							line_diff > actual_looseness && looseness >= line_diff) {
+						if ((line_diff < actual_looseness && looseness <= line_diff) ||
+							(line_diff > actual_looseness && looseness >= line_diff)) {
 							best_bet = r; actual_looseness = line_diff; fewest_demerits = total_demerits(r);
 						}
 						else if (line_diff == actual_looseness && total_demerits(r) < fewest_demerits) {
@@ -16010,8 +16010,8 @@ void unpackage()
 	c = cur_chr; scan_eight_bit_int(); p = box(cur_val);
 	if (p == null)
 		return;
-	if (myabs(mode) == mmode || myabs(mode) == vmode && type(p) != vlist_node ||
-		myabs(mode) == hmode && type(p) != hlist_node) {
+	if (myabs(mode) == mmode || (myabs(mode) == vmode && type(p) != vlist_node) ||
+		(myabs(mode) == hmode && type(p) != hlist_node)) {
 		print_err(TEX_STRING("Incompatible list can't be unboxed"));
 		help3(TEX_STRING("Sorry, Pandora. (You sneaky devil.)"),
 			TEX_STRING("I refuse to unbox an \hbox in vertical mode or vice versa."),

--- a/rstex.cpp.pre
+++ b/rstex.cpp.pre
@@ -60,6 +60,7 @@ for those who want to understand how this complex software works.
 */
 
 #include <sstream>
+#include <cmath>  // for round()
 
 #include "rstex.h"
 
@@ -2639,7 +2640,7 @@ void show_node_list(int p)
 						if (glue_sign(p) == shrinking) print(TEX_STRING("- "));
 						if (myabs(mem[p + glue_offset].union_t.an_int) < 04000000)
 							print(TEX_STRING("?.?"));
-						else if (abs(g) > float_constant(20000)) {
+						else if (myabs(g) > float_constant(20000)) {
 							if (g > float_constant(0)) print_char(TEX_STRING(">"));
 							else print(TEX_STRING("< -"));
 							print_glue(20000 * unity, glue_order(p), 0);

--- a/rstex.cpp.pre
+++ b/rstex.cpp.pre
@@ -2643,7 +2643,7 @@ void show_node_list(int p)
 						if (glue_sign(p) == shrinking) print(TEX_STRING("- "));
 						if (myabs(mem[p + glue_offset].union_t.an_int) < 04000000)
 							print(TEX_STRING("?.?"));
-						else if (myabs(g) > float_constant(20000)) {
+						else if (abs(g) > float_constant(20000)) {
 							if (g > float_constant(0)) print_char(TEX_STRING(">"));
 							else print(TEX_STRING("< -"));
 							print_glue(20000 * unity, glue_order(p), 0);

--- a/rstex.h.pre
+++ b/rstex.h.pre
@@ -746,7 +746,7 @@ const int inf_bad = 10000;
 #define set_glue_ratio_one(n) n=1.0
 #define _float(n) (float)n
 #define unfloat(n) glue_ratio(n)
-#define float_constant(n) n.0
+#define float_constant(n) n ## .0
 
 typedef float glue_ratio;
 


### PR DESCRIPTION
Firstly, thank you for this code! I have just started exploring it.

To compile on my compiler/computer (clang on macOS), I had to make a few changes. I have included them in this PR in case you'd like to consider incorporating them… feel free to reject!

- In one place, changed `abs` (which the compiler complained was ambiguous) to `myabs)
- Changed `#define float_constant(n) n.0` to `#define float_constant(n) n ## .0` — I think without it, something like `float_constant(1)` was not being tokenized as `1.0`, but as two tokens `1` and `.0` (like `1 .0`) which was causing an error
- The function `round` was not available without `#include <cmath>` (actually I worry about this `round` and rounding in general, and I haven't tested whether it still passes the trip test and/or whether this can be the source of any discrepancy between the “official” TeX program and others)

These three changes are in the first commit f347829. The other two commits consist of cosmetic changes that clang was emitting annoying warnings for: 1ae00dd for replacing things like `a || b && c` with `a || (b && c)`, and b67ffc9 for replacing `if (x) if (y) foo; else bar; with `if (x) { if (y) foo; else bar; }`. I considered just turning off these warnings, but in at least one place they pointed out confusing indentation, so I guess it's helpful.

Please take a look when (and if) you have some time. Cheers,