### PR TITLE
In the cpp file, include (as a comment) the string that was replaced

### DIFF
--- a/CreatePoolFile/CreatePoolFile.cpp
+++ b/CreatePoolFile/CreatePoolFile.cpp
@@ -124,7 +124,7 @@ int main(int argc, char **argv)
 				else {
 					index_of_string = replacement[0];// just use the character code in case of a one character string
 				}
-				output_file << index_of_string;
+				output_file << "/*" << replacement << "*/" << index_of_string;
 
 			}
 


### PR DESCRIPTION
A minor change :-) As one of the mentioned goals of your wonderful effort is educational (“it's not easy to understand or step through the code in a debugger”), I thought it might be nice to keep the strings in the `.cpp` file generated from the `.cpp.pre` file. 

It's the tiniest change, but the effect is that instead of 
```
print_err(656);
```
the generated  `.cpp` file will contain
```
print_err(/*Missing number, treated as zero*/656);
```
and this will be useful when stepping through the program in a debugger.